### PR TITLE
Update/oauth2 urls and use userid as login key

### DIFF
--- a/fyle_allauth/provider.py
+++ b/fyle_allauth/provider.py
@@ -23,7 +23,7 @@ class FyleProvider(OAuth2Provider):
         """
         Extracts the unique user ID from `data`
         """
-        return str(data['data']['id'])
+        return str(data['data']['user_id'])
 
     def extract_common_fields(self, data):
         """

--- a/fyle_allauth/views.py
+++ b/fyle_allauth/views.py
@@ -14,8 +14,8 @@ class FyleOAuth2Adapter(OAuth2Adapter):
     Fyle OAuth2Adapter
     """
     provider_id = FyleProvider.id
-    access_token_url = '{0}/api/oauth/token'.format(BASE_URL)
-    authorize_url = '{0}/app/main/#/oauth/authorize'.format(BASE_URL)
+    access_token_url = '{0}/oauth/token'.format(BASE_URL)
+    authorize_url = '{0}/app/developers/#/oauth/authorize'.format(BASE_URL)
     profile_url = '{0}/api/tpa/v1/employees/my_profile'.format(BASE_URL)
 
     def complete_login(self, request, app, token, **kwargs):


### PR DESCRIPTION
Update
- Fyle OAuth2.0 access_token and authorize_url to support all c
- Use user_id to uniquely identify a login